### PR TITLE
Impoved rate limiter to work with both sync and async functions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ AZURE_API_VERSION="" # "2024-07-01-preview"
 OPENAI_API_KEY="" # "my-openai-api-key"
 
 ANTHROPIC_API_KEY="" # "my-anthropic-api-key"
+
+# The maximum number of tokens per minute we can use when calling the LLMs
+MAX_TOKENS_PER_MINUTE="100000" 


### PR DESCRIPTION
Changes of this PR:
* The max tokens per minute is now an environment variable, making it easier to customize
* Both sync and async calls to LLMs will be rate-limited

Fixes #20 