### PR TITLE
[task, research] added labels for paper 10.1016:j.cognition.2020.104244

### DIFF
--- a/papers/10.1016:j.cognition.2020.104244/label_ken_c137_kg_original.json
+++ b/papers/10.1016:j.cognition.2020.104244/label_ken_c137_kg_original.json
@@ -1,0 +1,93 @@
+{
+    "nodes": [
+        {
+            "label": "Participant"
+        },
+        {
+            "label": "Chosen Robot"
+        },
+        {
+            "label": "Non-Chosen Robot"
+        },
+        {
+            "label": "Chosen-Unique Pattern"
+        },
+        {
+            "label": "Shared Pattern"
+        },
+        {
+            "label": "Non-Chosen Pattern"
+        },
+        {
+            "label": "Preferred Most"
+        },
+        {
+            "label": "Preferred Second"
+        },
+        {
+            "label": "Preferred Least"
+        }
+    ],
+    "edges": [
+        {
+            "source": "Participant",
+            "target": "Chosen Robot",
+            "label": "designs"
+        },
+        {
+            "source": "Participant",
+            "target": "Non-Chosen Robot",
+            "label": "does not design"
+        },
+        {
+            "source": "Chosen Robot",
+            "target": "Chosen-Unique Pattern",
+            "label": "has on back"
+        },
+        {
+            "source": "Chosen Robot",
+            "target": "Shared Pattern",
+            "label": "has on back"
+        },
+        {
+            "source": "Non-Chosen Robot",
+            "target": "Non-Chosen Pattern",
+            "label": "has on back"
+        },
+        {
+            "source": "Non-Chosen Robot",
+            "target": "Shared Pattern",
+            "label": "has on back"
+        },
+        {
+            "source": "Participant",
+            "target": "Chosen-Unique Pattern",
+            "label": "prefers most"
+        },
+        {
+            "source": "Participant",
+            "target": "Shared Pattern",
+            "label": "prefers second"
+        },
+        {
+            "source": "Participant",
+            "target": "Non-Chosen Pattern",
+            "label": "prefers least"
+        },
+        {
+            "source": "Chosen-Unique Pattern",
+            "target": "Preferred Most",
+            "label": "ranked as"
+        },
+        {
+            "source": "Shared Pattern",
+            "target": "Preferred Second",
+            "label": "ranked as"
+        },
+        {
+            "source": "Non-Chosen Pattern",
+            "target": "Preferred Least",
+            "label": "ranked as"
+        }
+    ]
+}

--- a/papers/10.1016:j.cognition.2020.104244/label_ken_c137_kg_perm_1.json
+++ b/papers/10.1016:j.cognition.2020.104244/label_ken_c137_kg_perm_1.json
@@ -1,0 +1,93 @@
+{
+    "nodes": [
+        {
+            "label": "Participant"
+        },
+        {
+            "label": "Chosen Robot"
+        },
+        {
+            "label": "Non-Chosen Robot"
+        },
+        {
+            "label": "Chosen-Unique Pattern"
+        },
+        {
+            "label": "Shared Pattern"
+        },
+        {
+            "label": "Non-Chosen Pattern"
+        },
+        {
+            "label": "Preferred Most"
+        },
+        {
+            "label": "Preferred Second"
+        },
+        {
+            "label": "Preferred Least"
+        }
+    ],
+    "edges": [
+        {
+            "source": "Participant",
+            "target": "Chosen Robot",
+            "label": "designs"
+        },
+        {
+            "source": "Participant",
+            "target": "Non-Chosen Robot",
+            "label": "does not design"
+        },
+        {
+            "source": "Chosen Robot",
+            "target": "Chosen-Unique Pattern",
+            "label": "has on back"
+        },
+        {
+            "source": "Chosen Robot",
+            "target": "Shared Pattern",
+            "label": "has on back"
+        },
+        {
+            "source": "Non-Chosen Robot",
+            "target": "Non-Chosen Pattern",
+            "label": "has on back"
+        },
+        {
+            "source": "Non-Chosen Robot",
+            "target": "Shared Pattern",
+            "label": "has on back"
+        },
+        {
+            "source": "Participant",
+            "target": "Chosen-Unique Pattern",
+            "label": "prefers least"
+        },
+        {
+            "source": "Participant",
+            "target": "Shared Pattern",
+            "label": "prefers second"
+        },
+        {
+            "source": "Participant",
+            "target": "Non-Chosen Pattern",
+            "label": "prefers most"
+        },
+        {
+            "source": "Chosen-Unique Pattern",
+            "target": "Preferred Least",
+            "label": "ranked as"
+        },
+        {
+            "source": "Shared Pattern",
+            "target": "Preferred Second",
+            "label": "ranked as"
+        },
+        {
+            "source": "Non-Chosen Pattern",
+            "target": "Preferred Most",
+            "label": "ranked as"
+        }
+    ]
+}


### PR DESCRIPTION
## Which issue this PR aims to address?
Issue #11 

## Team
Evaluator

## Stream
Research

## Nature of this PR
New ground truth labels

## Approach overview
I worked on this paper 10.1016:j.cognition.2020.104244 by first asking Claude to summarize the key results of the first experiment as a knowledge graph following instructions [here](https://docs.google.com/document/d/1LiHwXpT9NEm5wvNv8kLcZCcW63kIRUI2orqd2Xi_zN0/edit?tab=t.0). The resulting KG of the original result can be found in `papers/10.1016:j.cognition.2020.104244/label_ken_c137_kg_original.json`. 

I also created one alternative pattern where I swapped the conclusion. Specifically, the original result was that participants prefer the chosen unique pattern the most and the non-chosen unique pattern the least. I swapped their relationships.

## Justification
I thought it is entirely possible that people could prefer the pattern they did not choose as a contrasting theory of behaviour might be that they seek novelty.

## Limitations/Concerns
1. I am not entirely sure how grounded my alternative result is in existing literature. 
2. I am concerned about this approach's limitation - what if there is a paper where its alternative does not exist in the original text. For instance, if the paper is about brain region A causes X effect in brain region B where we can swap A and B but if the paper is written in a way that says after experiment M, we found brain region A has activation Y. How may we create alternatives? Should be combine knowledge from multiple papers?